### PR TITLE
Use pandas to read observations

### DIFF
--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -385,19 +385,31 @@ class FrameDB:
         for f in self.data_files.values():
             f.close()
 
-    def load_hdf5(self, hdf5_file: str, skip: int = 0, limit: Optional[int] = None):
+    def load_hdf5(
+            self,
+            hdf5_file: str,
+            skip: int = 0,
+            limit: Optional[int] = None,
+            key: str = "data",
+            chunksize: int = 100000
+        ):
         """
         Load data from an NSC HDF5 catalog file.
 
         hdf5_file: Path to a file on disk.
         skip: Number of frames to skip in the file.
         limit: Maximum number of frames to load from the file. None means no limit.
+        key: Name of observations table in the hdf5 file.
+        chunksize: Load observations in chunks of this size and then iterate over the chunks
+            to load observations.
         """
         for src_frame in sourcecatalog.iterate_frames(
             hdf5_file,
             limit,
             nside=self.healpix_nside,
             skip=skip,
+            key=key,
+            chunksize=chunksize
         ):
             observations = [Observation.from_srcobs(o) for o in src_frame.observations]
             data_uri, offset, length = self.store_observations(observations)

--- a/precovery/sourcecatalog.py
+++ b/precovery/sourcecatalog.py
@@ -120,19 +120,24 @@ def iterate_observations(filename: str, key="data", chunksize=100000) -> Iterato
                 chunksize=chunksize,
                 columns=["obs_id", "exposure_id", "mjd_utc", "ra", "dec"]
             ):
-                for i, row in chunk.iterrows():
+                exposure_ids = chunk.exposure_id.values
+                ids = chunk.obs_id.values
+                decs = chunk.dec.values
+                ras = chunk.ra.values
+                epochs = chunk.mjd_utc.values
 
-                    exposure_id = row.exposure_id
-                    obscode = _obscode_from_exposure_id(exposure_id)
-                    id = row.obs_id.encode()
-                    dec = row.dec
-                    ra = row.ra
-                    epoch = row.mjd_utc
+                for exposure_id, id, ra, dec, epoch in zip(
+                    exposure_ids,
+                    ids,
+                    ras,
+                    decs,
+                    epochs
+                ):
+                    obscode = _obscode_from_exposure_id(exposure_id.encode())
 
-                    obs = SourceObservation(exposure_id, obscode, id, ra, dec, epoch)
+                    obs = SourceObservation(exposure_id, obscode, id.encode(), ra, dec, epoch)
                     yield (obs)
                     progress.update(read_observations, advance=1)
-
 
 def _obscode_from_exposure_id(exposure_id: bytes) -> str:
     # The table has no explicit information on which instrument sourced the

--- a/precovery/sourcecatalog.py
+++ b/precovery/sourcecatalog.py
@@ -114,8 +114,7 @@ def iterate_observations(filename: str, key="data", chunksize=100000) -> Iterato
             read_observations = progress.add_task(
                 "loading observations...", total=n_rows
             )
-            for chunk in pd.read_hdf(
-                store,
+            for chunk in store.select(
                 key=key,
                 iterator=True,
                 chunksize=chunksize,

--- a/precovery/sourcecatalog.py
+++ b/precovery/sourcecatalog.py
@@ -142,16 +142,16 @@ def iterate_observations(filename: str, key="data", chunksize=100000) -> Iterato
                     decs,
                     epochs
                 ):
-                    obscode = _obscode_from_exposure_id(exposure_id.encode())
+                    obscode = _obscode_from_exposure_id(exposure_id)
 
                     obs = SourceObservation(exposure_id, obscode, id.encode(), ra, dec, epoch)
                     yield (obs)
                     progress.update(read_observations, advance=1)
 
-def _obscode_from_exposure_id(exposure_id: bytes) -> str:
+def _obscode_from_exposure_id(exposure_id: str) -> str:
     # The table has no explicit information on which instrument sourced the
     # exposure. We have to glean it out of the exposure ID.
-    exp_prefix = exposure_id[:3].decode()
+    exp_prefix = exposure_id[:3]
     if exp_prefix == "c4d":
         # The CTIO-4m with DECam.
         return "807"
@@ -163,5 +163,5 @@ def _obscode_from_exposure_id(exposure_id: bytes) -> str:
         return "695"
     else:
         raise ValueError(
-            f"can't determine instrument for exposure {exposure_id.decode()}"
+            f"can't determine instrument for exposure {exposure_id}"
         )

--- a/precovery/sourcecatalog.py
+++ b/precovery/sourcecatalog.py
@@ -98,7 +98,7 @@ def iterate_exposures(filename, limit: Optional[int] = None, skip: int = 0):
     yield current_exposure
 
 
-def iterate_observations(filename: str, key="data", chunksize=10000) -> Iterator[SourceObservation]:
+def iterate_observations(filename: str, key="data", chunksize=100000) -> Iterator[SourceObservation]:
 
     with pd.HDFStore(filename, key=key, mode="r") as store:
 
@@ -114,7 +114,13 @@ def iterate_observations(filename: str, key="data", chunksize=10000) -> Iterator
             read_observations = progress.add_task(
                 "loading observations...", total=n_rows
             )
-            for chunk in pd.read_hdf(store, key=key, iterator=True, chunksize=chunksize):
+            for chunk in pd.read_hdf(
+                store,
+                key=key,
+                iterator=True,
+                chunksize=chunksize,
+                columns=["obs_id", "exposure_id", "mjd_utc", "ra", "dec"]
+            ):
                 for i, row in chunk.iterrows():
 
                     exposure_id = row.exposure_id

--- a/precovery/sourcecatalog.py
+++ b/precovery/sourcecatalog.py
@@ -39,8 +39,10 @@ def iterate_frames(
     limit: Optional[int] = None,
     nside: int = 32,
     skip: int = 0,
+    key: str = "data",
+    chunksize: int = 100000
 ) -> Iterator[SourceFrame]:
-    for exp in iterate_exposures(filename, limit, skip):
+    for exp in iterate_exposures(filename, limit, skip, key, chunksize):
         for frame in source_exposure_to_frames(exp, nside):
             yield frame
 
@@ -65,10 +67,17 @@ def source_exposure_to_frames(
     return list(by_pixel.values())
 
 
-def iterate_exposures(filename, limit: Optional[int] = None, skip: int = 0):
+def iterate_exposures(
+        filename,
+        limit:
+        Optional[int] = None,
+        skip: int = 0,
+        key: str = "data",
+        chunksize: int = 100000
+    ):
     current_exposure: Optional[SourceExposure] = None
     n = 0
-    for obs in iterate_observations(filename):
+    for obs in iterate_observations(filename, key=key, chunksize=chunksize):
         if current_exposure is None:
             # first iteration
             current_exposure = SourceExposure(

--- a/requirements.in
+++ b/requirements.in
@@ -3,4 +3,5 @@ numba==0.53.1
 sqlalchemy
 rich
 tables
+pandas
 healpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile requirements.in
 #
-astropy==4.3.1
+astropy==5.0
     # via healpy
 colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
-cycler==0.10.0
+cycler==0.11.0
+    # via matplotlib
+fonttools==4.28.2
     # via matplotlib
 greenlet==1.1.2
     # via sqlalchemy
@@ -20,7 +22,7 @@ kiwisolver==1.3.2
     # via matplotlib
 llvmlite==0.36.0
     # via numba
-matplotlib==3.4.3
+matplotlib==3.5.0
     # via healpy
 numba==0.53.1
     # via -r requirements.in
@@ -34,31 +36,49 @@ numpy==1.21.4
     #   matplotlib
     #   numba
     #   numexpr
+    #   pandas
     #   pyerfa
     #   scipy
     #   tables
-pillow==8.3.2
+packaging==21.3
+    # via
+    #   astropy
+    #   matplotlib
+    #   setuptools-scm
+pandas==1.3.4
+    # via -r requirements.in
+pillow==8.4.0
     # via matplotlib
-pyerfa==2.0.0
+pyerfa==2.0.0.1
     # via astropy
 pygments==2.10.0
     # via rich
-pyparsing==2.4.7
-    # via matplotlib
-python-dateutil==2.8.2
-    # via matplotlib
-rich==10.12.0
-    # via -r requirements.in
-scipy==1.7.1
-    # via healpy
-six==1.16.0
+pyparsing==3.0.6
     # via
-    #   cycler
-    #   python-dateutil
-sqlalchemy==1.4.25
+    #   matplotlib
+    #   packaging
+python-dateutil==2.8.2
+    # via
+    #   matplotlib
+    #   pandas
+pytz==2021.3
+    # via pandas
+pyyaml==6.0
+    # via astropy
+rich==10.15.1
+    # via -r requirements.in
+scipy==1.7.3
+    # via healpy
+setuptools-scm==6.3.2
+    # via matplotlib
+six==1.16.0
+    # via python-dateutil
+sqlalchemy==1.4.27
     # via -r requirements.in
 tables==3.6.1
     # via -r requirements.in
+tomli==1.2.2
+    # via setuptools-scm
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Reading hdf5 files and iterating over rows can be difficult especially if the underlying file structure changes with the addition or removal of columns. This PR replaces `tables` with `pandas` to read hdf5 files. `pandas` adds some very convenient functionality to allow iteration over an hdf5 file in chunks. Note, however, that this only works if the hdf5 file was saved with `format="table"` (see: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_hdf.html). 

I haven't tested the performance of this change. 