### PR TITLE
Add Config class, serialize config to JSON 

### DIFF
--- a/precovery/config.py
+++ b/precovery/config.py
@@ -1,0 +1,58 @@
+import json
+
+class Config:
+
+    def __init__(self,
+            nside: int = 32,
+            data_file_max_size: int = int(1e9)
+        ):
+        """
+        Precovery Database Configuration
+
+        Parameters
+        ----------
+        nside : int
+            Observations are indexed in HealpixFrames for each unique mjd and observatory_code.
+            The nside parameter sets the size of the healpixelization.
+        data_file_max_size : int
+            Maximum size in bytes of the binary files to which the indexed observations are
+            saved.
+        """
+        self.nside = nside
+        self.data_file_max_size = data_file_max_size
+
+        return
+
+    def to_json(self, out_file):
+        """
+        Save Config as .json.
+
+        Parameters
+        ----------
+        out_file : str
+            Desired path and name of file to which to save config.
+        """
+        with open(out_file, 'w', encoding='utf-8') as file:
+            json.dump(
+                self.__dict__,
+                file,
+                ensure_ascii=False,
+                indent=4
+            )
+        return
+
+    @classmethod
+    def from_json(cls, in_file: str) -> "Config":
+        """
+        Load Config from .json.
+
+        Parameters
+        ----------
+        in_file : str
+            Desired path and name of file from which to load config.
+        """
+        with open(in_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(**data)
+
+DefaultConfig = Config()

--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -4,11 +4,22 @@ import itertools
 import logging
 import os
 import struct
-from typing import Iterable, Iterator, Optional, Set, Tuple
+from typing import (
+    Iterable,
+    Iterator,
+    Optional,
+    Set,
+    Tuple
+)
 
 import numpy as np
 import sqlalchemy as sq
-from rich.progress import BarColumn, Progress, TimeElapsedColumn, TimeRemainingColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TimeElapsedColumn,
+    TimeRemainingColumn
+)
 from sqlalchemy.sql import func as sqlfunc
 
 from . import sourcecatalog

--- a/precovery/healpix_geom.py
+++ b/precovery/healpix_geom.py
@@ -2,8 +2,5 @@ import healpy as hp
 import numpy as np
 import numpy.typing as npt
 
-def radec_to_healpixel(ra: float, dec: float, nside: int) -> int:
-    return hp.ang2pix(nside, ra, dec, nest=True, lonlat=True)
-
 def radec_to_healpixel(ra: npt.NDArray[np.float64], dec: npt.NDArray[np.float64], nside: int) -> npt.NDArray[np.intc]:
     return hp.ang2pix(nside, ra, dec, nest=True, lonlat=True).astype(np.intc)


### PR DESCRIPTION
This relatively simple change adds a configuration class that stores the parameters with which a precovery database and its indexed binary files were created. 