### PR TITLE
Add dataset_id to frames, add datasets table to index.db

### DIFF
--- a/precovery/main.py
+++ b/precovery/main.py
@@ -34,6 +34,7 @@ def _candidates_to_dict(candidates):
         'delta_ra_arcsec': [],
         'delta_dec_arcsec': [],
         'distance_arcsec': [],
+        'dataset_id' : [],
     }
     for c in candidates:
         for k in data.keys():

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -56,6 +56,7 @@ class PrecoveryCandidate:
     delta_ra_arcsec: float
     delta_dec_arcsec: float
     distance_arcsec: float
+    dataset_id: str
 
 @dataclasses.dataclass
 class FrameCandidate:
@@ -68,6 +69,7 @@ class FrameCandidate:
     pred_dec_deg: float
     pred_vra_degpday: float
     pred_vdec_degpday: float
+    dataset_id: str
 
 class PrecoveryDatabase:
     def __init__(self, frames: FrameDB):
@@ -379,7 +381,8 @@ class PrecoveryDatabase:
                         pred_vdec_degpday=exact_ephem.dec_velocity,
                         delta_ra_arcsec=dra/ARCSEC,
                         delta_dec_arcsec=ddec/ARCSEC,
-                        distance_arcsec=distance/ARCSEC
+                        distance_arcsec=distance/ARCSEC,
+                        dataset_id=f.dataset_id,
                     )
                     yield candidate
 
@@ -395,6 +398,7 @@ class PrecoveryDatabase:
                         pred_dec_deg=exact_ephem.dec,
                         pred_vra_degpday=exact_ephem.ra_velocity,
                         pred_vdec_degpday=exact_ephem.dec_velocity,
+                        dataset_id=f.dataset_id,
                     )
                     yield frame_candidate
 

--- a/scripts/index_observations.py
+++ b/scripts/index_observations.py
@@ -18,6 +18,10 @@ if __name__ == "__main__":
         help="Directory where the indexed observations and database should be saved.",
         type=str
     )
+    parser.add_argument("dataset_id",
+        help="Dataset ID for this file.",
+        type=str
+    )
     parser.add_argument("--nside",
         default=DefaultConfig.nside,
         type=int,
@@ -29,10 +33,31 @@ if __name__ == "__main__":
         type=int,
         help="Maximum size in bytes of the binary indexed observation files."
     )
+    parser.add_argument("--dataset_name",
+        help="Dataset name for this file.",
+        type=str,
+        default=None
+    )
+    parser.add_argument("--reference_doi",
+        help="DOI of the reference paper for this dataset.",
+        type=str,
+        default=None
+    )
+    parser.add_argument("--documentation_url",
+        help="URL of any documentation available for this dataset.",
+        type=str
+    )
+    parser.add_argument("--sia_url",
+        help="Simple Image Access URL for this dataset.",
+        type=str
+    )
 
     args = parser.parse_args()
 
     files = sorted(glob.glob(os.path.join(args.data_dir, "*.h5")))
+    # python index_observations.py /mnt/data/projects/thor/thor_data/nsc/preprocessed /mnt/data/projects/precovery/precovery_data/nsc/precovery_month_db_32_test NSC_DR2 
+    # --nside 32 --dataset_name "NOIRLab Source Catalog (DR2)" --reference_doi https://doi.org/10.3847/1538-3881/abd6e1 
+    # --documentation_url https://datalab.noirlab.edu/nscdr2/index.php --sia_url https://datalab.noirlab.edu/sia/nsc_dr2
     print(f"Found {len(files)} observation files in {args.data_dir}:")
     for f in files:
         print(f"\t{os.path.basename(f)}")
@@ -54,7 +79,14 @@ if __name__ == "__main__":
     for i, observations_file in enumerate(files):
         print(f"Processing ({i + 1}/{len(files)}): {observations_file}")
         if observations_file not in set(read_files):
-            db.frames.load_hdf5(observations_file)
+            db.frames.load_hdf5(
+                observations_file, 
+                args.dataset_id,
+                name=args.dataset_name,
+                reference_doi=args.reference_doi,
+                documentation_url=args.documentation_url,
+                sia_url=args.sia_url
+            )
             read_files.append(observations_file)
             np.savetxt(status_file, read_files, fmt="%s", delimiter='\n')
         else:


### PR DESCRIPTION
This PR adds a dataset_id column to the frames table:
```
id | dataset_id | obscode | exposure_id | filter | mjd | healpixel | data_uri | data_offset | data_length
1 | NSC_DR2 | W84 | c4d_130802_044515_ooi_z_a1 | z | 56506.198093 | 4217 | frames_00000000.data | 0 | 12829
2 | NSC_DR2 | W84 | c4d_130802_044515_ooi_z_a1 | z | 56506.198093 | 4216 | frames_00000000.data | 12829 | 690
3 | NSC_DR2 | W84 | c4d_130802_044515_ooi_z_a1 | z | 56506.198093 | 4210 | frames_00000000.data | 13519 | 412
4 | NSC_DR2 | W84 | c4d_130802_044515_ooi_z_a1 | z | 56506.198093 | 4211 | frames_00000000.data | 13931 | 7146
5 | NSC_DR2 | W84 | c4d_130802_044615_ooi_z_a1 | z | 56506.198794 | 4217 | frames_00000000.data | 21077 | 16415
6 | NSC_DR2 | W84 | c4d_130802_044615_ooi_z_a1 | z | 56506.198794 | 4216 | frames_00000000.data | 37492 | 828
7 | NSC_DR2 | W84 | c4d_130802_044615_ooi_z_a1 | z | 56506.198794 | 4210 | frames_00000000.data | 38320 | 826
8 | NSC_DR2 | W84 | c4d_130802_044615_ooi_z_a1 | z | 56506.198794 | 4211 | frames_00000000.data | 39146 | 9012
9 | NSC_DR2 | W84 | c4d_130802_044713_ooi_z_a1 | z | 56506.199465 | 4217 | frames_00000000.data | 48158 | 14546
10 | NSC_DR2 | W84 | c4d_130802_044713_ooi_z_a1 | z | 56506.199465 | 4216 | frames_00000000.data | 62704 | 828
```
This column is also extended to the `PrecoveryCandidate` and `FrameCandidate` classes allowing the user to know from which dataset the observation actually came which will be useful as we start indexing more data. 

A datasets table that is designed to track metadata for the input dataset is also added. All quantities except the `id` are optional and nullable.
```
id | name | reference_doi | documentation_url | sia_url
NSC_DR2 | NOIRLab Source Catalog (DR2) | https://doi.org/10.3847/1538-3881/abd6e1 | https://datalab.noirlab.edu/nscdr2/index.php | https://datalab.noirlab.edu/sia/nsc_dr2
```

If we merge this PR, existing indexed observation databases will need to be updated with the new column and table. This can be accomplished with the following snippet: 
```
import os
import shutil
import pandas as pd
import sqlite3 as sql

# Precovery database and indexed observations directory location
DB_DIR = "/epyc/ssd/users/moeyensj/precovery/precovery_data/nsc/precovery_defrag_db_032"
DB = os.path.join(DB_DIR, "index.db")

DB_COPY = os.path.join(DB_DIR, "index.db_backup")
if not os.path.exists(DB_COPY):
    shutil.copyfile(DB, DB_COPY)
    
    con = sql.connect(DB)

    frames = pd.read_sql("""SELECT * FROM frames""", con)
    frames.insert(1, "dataset_id", "NSC_DR2")
    frames.to_sql("frames", con, if_exists="replace", index=False)

    datasets = {
        "id" : ["NSC_DR2"],
        "name" : ["NOIRLab Source Catalog (DR2)"],
        "reference_doi" : ["https://doi.org/10.3847/1538-3881/abd6e1"],
        "documentation_url" : ["https://datalab.noirlab.edu/nscdr2/index.php"],
        "sia_url" : ["https://datalab.noirlab.edu/sia/nsc_dr2"],
    }
    datasets = pd.DataFrame(datasets)
    datasets.to_sql("datasets", con, if_exists="replace", index=False)
    con.close()
```