### PR TITLE
Add Orbit.from_Horizons convenience function

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,8 @@ pytables
 pandas
 healpy
 requests
+astropy
+astroquery
 pytest
 pytest-cov
 setuptools>=45

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ pandas
 healpy
 requests
 openorb
+astropy
+astroquery
 pytest
 pytest-cov
 setuptools>=45


### PR DESCRIPTION
This PR adds a classmethod to the Orbit class that loads an orbit from JPL Horizons. This is functionality that is extremely useful and is based on THOR's method of the same name but in the absence of an `adam.core` package, I duplicate it here and modify it slightly to fit the precovery context.

You can now load an orbit as follows:
```
from astropy.time import Time
from precovery.orbit import Orbit

t0 = Time(59000, scale="utc", format="mjd")
orbit = Orbit.from_Horizons("Ivezic", t0)
``` 
The downside is that we add astroquery and astropy as dependencies, though given how commonplace these packages are I think that should be okay. 