### PR TITLE
Make precovery install editable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN mkdir /code/
 ADD . /code/
 WORKDIR /code/
 
-RUN SETUPTOOLS_SCM_PRETEND_VERSION=1 pip install .[tests]
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=1 pip install -e .[tests]


### PR DESCRIPTION
Make the precovery installation editable to avoid having to rebuild the image when changes are made to the code. 