### PR TITLE
Use arch-specific wheel of healpy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,17 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     export WHEEL_NAME="${OORB_VERSION}-cp310-cp310-manylinux_2_17_$(uname -m).manylinux2014_$(uname -m).whl" && \
     pip install "https://github.com/B612-Asteroid-Institute/oorb/releases/download/${OORB_TAG}/${WHEEL_NAME}"
 
+# HACK: Install healpy from a release hosted on our fork. This fork
+# has no actual changes from upstream healpy. The only purpose of this
+# is to install an architecture-specific wheel, since as of 1.16.2
+# healpy only produces x86_64 wheels, and M1 Macbooks use aarch64.
+#
+# The 1.16.3 release of healpy is expected to include aarch64 wheels;
+# once that is released and used by precovery this can be removed.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    export WHEEL_NAME="healpy-1.16.2-cp310-cp310-manylinux_2_17_$(uname -m).manylinux2014_$(uname -m).whl" && \
+    pip install "https://github.com/B612-Asteroid-Institute/healpy/releases/download/1.16.2/${WHEEL_NAME}"
+
 # Install precovery
 RUN mkdir -p /code/precovery
 # Install precovery dependencies

--- a/README.md
+++ b/README.md
@@ -28,10 +28,22 @@ To install the bleeding edge source code, clone this repository and then:
 `pip install .`  
 
 
-**openorb**
+#### openorb
 
 Note that, `openorb` is not available on the Python Package Index and so you wil need
 to install it via source or conda. See the `Dockerfile` for example of how to build on Ubuntu linux.
+
+
+#### healpy
+
+`healpy` is available on PyPI, but as of version 1.16.2, only x86_64 wheels are published.
+For developers using Apple M1 Macbooks, these wheels won't be runnable.
+
+Alternative wheels are therefore currently available on a [B612 fork](https://github.com/B612-Asteroid-Institute/healpy).
+`aarch64` linux wheels can be found here: https://github.com/B612-Asteroid-Institute/healpy/releases/tag/1.16.2
+
+Those wheels can be downloaded and directly pip-installed for developers using Docker containers on M1 Macbooks.
+See the `Dockerfile` for example.
 
 ## Developer Setup
 


### PR DESCRIPTION
In working through #59, I wanted to make it so that you could run `pre-commit` in a dockerized workflow. Ideally, you'd be able to do something like `docker-compose run precovery pre-commit run --all-files`, and it'd scan all files, just like you'd ask.

But I found this was too slow when using x86_64 emulation on my macbook. In particular, running mypy checks across all files took more than an 40 minutes (!!!). I ended up killing the process and giving up.

The only reason we're using x86_64 emulation right now is that healpy doesn't have a binary wheel for aarch64 released yet. The work to make aarch64 wheels was done in https://github.com/healpy/healpy/pull/819, but there just hasn't been a healpy release since then. So, I decided to copy the pattern set in #57: I made a B612 fork of healpy, and used it to host built wheels. I set up the Dockerfile to manually install the wheel.

With this, running mypy checks takes a few seconds, so pre-commit from within docker is feasible.