### PR TITLE
Use SQLAlchemy 1.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,5 +36,5 @@ repos:
   - id: mypy
     additional_dependencies:
       - numpy
-      - sqlalchemy
+      - sqlalchemy<2
       - types-requests

--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -126,7 +126,11 @@ class FrameIndex:
         if db_uri.startswith("sqlite:///") and (mode == "r"):
             db_uri += "?mode=ro"
 
-        engine = sq.create_engine(db_uri, connect_args={"timeout": 60})
+        # future=True is required here for SQLAlchemy 2.0 API usage
+        # while we migrate from 1.x up. Version 2 is incompatible with
+        # dagster, so we need to actually pin to 1.x, but future=True
+        # lets us use the 2.0 API in this code.
+        engine = sq.create_engine(db_uri, connect_args={"timeout": 60}, future=True)
 
         # Check if fast_query index exists (older databases may not have it)
         # if it doesn't throw a warning with the command to create it

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
 install_requires =
     numpy
     numba
-    sqlalchemy >= 2.0.0
+    sqlalchemy < 2
     regex
     tables <= 3.7
     pandas


### PR DESCRIPTION
Dagster is incompatible with SQLAlchemy 2, and we use dagster to run precovery jobs. Unfortunately, this means we need to revert the changes in #66.