### PR TITLE
Add test case which shows failure to combine frames together

### DIFF
--- a/precovery/sourcecatalog.py
+++ b/precovery/sourcecatalog.py
@@ -89,6 +89,7 @@ def bundle_into_frames(
 
             # Reset observations dictionary
             observations_by_healpixel.clear()
+            cur_exposure_id = obs.exposure_id
 
         healpixel = healpix_geom.radec_to_healpixel(obs.ra, obs.dec, nside)
         observations_by_healpixel[healpixel].append(obs)

--- a/tests/test_frame_db.py
+++ b/tests/test_frame_db.py
@@ -257,7 +257,7 @@ def test_add_frames_dedupes_sorted_exposures(frame_db):
     """
     observations = [
         make_sourceobs(
-            exposure_id="exp1",
+            exposure_id=b"exp0",
             id=b"obs1",
             healpixel=1,
         ),
@@ -289,10 +289,10 @@ def test_add_frames_dedupes_sorted_exposures(frame_db):
     ]
     frames = list(bundle_into_frames(observations))
 
-    assert len(frames) == 3
+    assert len(frames) == 4
 
     dataset_id = "test_dataset"
     frame_db.add_dataset(dataset_id)
     frame_db.add_frames(dataset_id, frames)
 
-    assert len(list(frame_db.idx.all_frames())) == 3
+    assert len(list(frame_db.idx.all_frames())) == 4

--- a/tests/test_frame_db.py
+++ b/tests/test_frame_db.py
@@ -5,7 +5,9 @@ import pytest
 from astropy.time import Time
 
 from precovery.frame_db import FrameDB, FrameIndex
-from precovery.sourcecatalog import SourceFrame, SourceObservation
+from precovery.sourcecatalog import SourceFrame, SourceObservation, bundle_into_frames
+
+from .testutils import make_sourceobs
 
 
 @pytest.fixture
@@ -245,3 +247,52 @@ def test_add_frames(frame_db):
     # Get associated observations
     stored_obs1 = list(frame_db.iterate_observations(stored_frame_1))
     assert len(stored_obs1) == 2
+
+
+def test_add_frames_dedupes_sorted_exposures(frame_db):
+    """When the database ingests sorted exposure data, observations
+    from the same frame should just generate one row in the index for
+    the frame, not multiple.
+
+    """
+    observations = [
+        make_sourceobs(
+            exposure_id="exp1",
+            id=b"obs1",
+            healpixel=1,
+        ),
+        make_sourceobs(
+            exposure_id=b"exp1",
+            id=b"obs2",
+            healpixel=1,
+        ),
+        make_sourceobs(
+            exposure_id=b"exp1",
+            id=b"obs3",
+            healpixel=1,
+        ),
+        make_sourceobs(
+            exposure_id=b"exp1",
+            id=b"obs4",
+            healpixel=2,
+        ),
+        make_sourceobs(
+            exposure_id=b"exp1",
+            id=b"obs5",
+            healpixel=2,
+        ),
+        make_sourceobs(
+            exposure_id=b"exp2",
+            id=b"obs6",
+            healpixel=1,
+        ),
+    ]
+    frames = list(bundle_into_frames(observations))
+
+    assert len(frames) == 3
+
+    dataset_id = "test_dataset"
+    frame_db.add_dataset(dataset_id)
+    frame_db.add_frames(dataset_id, frames)
+
+    assert len(list(frame_db.idx.all_frames())) == 3

--- a/tests/test_sourcecatalog.py
+++ b/tests/test_sourcecatalog.py
@@ -144,3 +144,38 @@ class TestBundleObservationsIntoFrames:
         result = list(frames)
 
         assert len(result) == 5
+
+    def test_multiple_exposures_2(self):
+        observations = [
+            # Frame 1: exp1, healpixel 1, 3 observations
+            make_sourceobs(
+                exposure_id=b"exp0",
+                healpixel=1,
+            ),
+            make_sourceobs(
+                exposure_id=b"exp1",
+                healpixel=1,
+            ),
+            make_sourceobs(
+                exposure_id=b"exp1",
+                healpixel=1,
+            ),
+            # Frame 2: exp1, healpixel 2, 2 observations
+            make_sourceobs(
+                exposure_id=b"exp1",
+                healpixel=2,
+            ),
+            make_sourceobs(
+                exposure_id=b"exp1",
+                healpixel=2,
+            ),
+            # Frame 3: exp2, healpixel 1, 1 observation
+            make_sourceobs(
+                exposure_id=b"exp2",
+                healpixel=1,
+            ),
+        ]
+        frames = list(bundle_into_frames(observations))
+
+        result = list(frames)
+        assert len(result) == 4

--- a/tests/test_sourcecatalog.py
+++ b/tests/test_sourcecatalog.py
@@ -1,49 +1,6 @@
-import random
-from typing import Optional, Tuple
+from precovery.sourcecatalog import SourceFrame, bundle_into_frames
 
-import healpy
-
-from precovery.sourcecatalog import SourceFrame, SourceObservation, bundle_into_frames
-
-
-def make_sourceobs(
-    exposure_id: str = "exposure",
-    id: Optional[bytes] = None,
-    healpixel: Optional[int] = None,
-    nside: int = 32,
-    ra: float = 1.0,
-    dec: float = 2.0,
-) -> SourceObservation:
-
-    if id is None:
-        id = random.randbytes(16)
-
-    if healpixel is not None:
-        ra, dec = radec_for_healpixel(healpixel, nside)
-
-    return SourceObservation(
-        exposure_id=exposure_id,
-        obscode="obs",
-        id=id,
-        mjd=50000,
-        ra=ra,
-        dec=dec,
-        ra_sigma=3.0,
-        dec_sigma=4.0,
-        mag=5.0,
-        mag_sigma=6.0,
-        filter="filter",
-        exposure_mjd_start=50000,
-        exposure_mjd_mid=50000,
-        exposure_duration=30,
-    )
-
-
-def radec_for_healpixel(healpixel: int, nside: int) -> Tuple[float, float]:
-    """
-    Compute the ra and dec associated with a healpixel
-    """
-    return healpy.pix2ang(nside=nside, ipix=healpixel, nest=True, lonlat=True)
+from .testutils import make_sourceobs
 
 
 def test_sourceframe_from_observation():

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,0 +1,46 @@
+import random
+from typing import Optional, Tuple
+
+import healpy
+
+from precovery.sourcecatalog import SourceObservation
+
+
+def make_sourceobs(
+    exposure_id: str = "exposure",
+    id: Optional[bytes] = None,
+    healpixel: Optional[int] = None,
+    nside: int = 32,
+    ra: float = 1.0,
+    dec: float = 2.0,
+) -> SourceObservation:
+
+    if id is None:
+        id = random.randbytes(16)
+
+    if healpixel is not None:
+        ra, dec = radec_for_healpixel(healpixel, nside)
+
+    return SourceObservation(
+        exposure_id=exposure_id,
+        obscode="obs",
+        id=id,
+        mjd=50000,
+        ra=ra,
+        dec=dec,
+        ra_sigma=3.0,
+        dec_sigma=4.0,
+        mag=5.0,
+        mag_sigma=6.0,
+        filter="filter",
+        exposure_mjd_start=50000,
+        exposure_mjd_mid=50000,
+        exposure_duration=30,
+    )
+
+
+def radec_for_healpixel(healpixel: int, nside: int) -> Tuple[float, float]:
+    """
+    Compute the ra and dec associated with a healpixel
+    """
+    return healpy.pix2ang(nside=nside, ipix=healpixel, nest=True, lonlat=True)


### PR DESCRIPTION
The `test_add_frames_dedupes_sorted_exposures` test case fails. `len(frames)` is 6 instead of 3.