### PR TITLE
Empty csvs cause null values in precovery db

### DIFF
--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -529,8 +529,11 @@ class FrameIndex:
             }
             for frame in frames
         ]
-        self.dbconn.execute(insert, values)
-        self.dbconn.commit()
+        if len(values) > 0:
+            self.dbconn.execute(insert, values)
+            self.dbconn.commit()
+        else:
+            logger.warning("No frames to add")
 
     def add_dataset(self, dataset: Dataset):
         """


### PR DESCRIPTION
This fix checks that we actually have found frames before committing them to the frame database