### PR TITLE
Sort candidates by MJD and observation ID

### DIFF
--- a/precovery/main.py
+++ b/precovery/main.py
@@ -159,17 +159,14 @@ def precover(
         allow_version_mismatch=allow_version_mismatch,
     )
 
-    candidates = [
-        c
-        for c in precovery_db.precover(
-            orbit,
-            tolerance=tolerance,
-            start_mjd=start_mjd,
-            end_mjd=end_mjd,
-            window_size=window_size,
-            include_frame_candidates=include_frame_candidates,
-        )
-    ]
+    candidates = precovery_db.precover(
+        orbit,
+        tolerance=tolerance,
+        start_mjd=start_mjd,
+        end_mjd=end_mjd,
+        window_size=window_size,
+        include_frame_candidates=include_frame_candidates,
+    )
 
     df = pd.DataFrame(_candidates_to_dict(candidates))
     df.loc[:, "observation_id"] = df.loc[:, "observation_id"].astype(str)

--- a/precovery/main.py
+++ b/precovery/main.py
@@ -105,7 +105,6 @@ def precover(
     orbit: Orbit,
     database_directory: str,
     tolerance: float = 1 / 3600,
-    max_matches: Optional[int] = None,
     start_mjd: Optional[float] = None,
     end_mjd: Optional[float] = None,
     window_size: int = 7,
@@ -126,8 +125,6 @@ def precover(
     tolerance : float, optional
         The on-sky angular tolerance in degrees to which any PrecoveryCandidates should be
         returned.
-    max_matches : int, optional
-        Don't return more than this many potential PrecoveryCandidates.
     start_mjd : float, optional
         Limit precovery search to all MJD UTC times beyond this time.
     end_mjd : float, optional
@@ -167,7 +164,6 @@ def precover(
         for c in precovery_db.precover(
             orbit,
             tolerance=tolerance,
-            max_matches=max_matches,
             start_mjd=start_mjd,
             end_mjd=end_mjd,
             window_size=window_size,

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -145,7 +145,6 @@ class PrecoveryDatabase:
         self,
         orbit: Orbit,
         tolerance: float = 30 * ARCSEC,
-        max_matches: Optional[int] = None,
         start_mjd: Optional[float] = None,
         end_mjd: Optional[float] = None,
         window_size: int = 7,
@@ -186,7 +185,6 @@ class PrecoveryDatabase:
             if end_mjd is None:
                 end_mjd = last
 
-        n = 0
         logger.info(
             "precovering orbit %s from %.5f to %.5f, window=%d",
             orbit.orbit_id,
@@ -214,9 +212,6 @@ class PrecoveryDatabase:
             )
             for result in matches:
                 yield result
-                n += 1
-                if max_matches is not None and n >= max_matches:
-                    return
 
     def _check_windows(
         self,

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -83,16 +83,26 @@ def sort_candidates(candidates: List[Union[PrecoveryCandidate, FrameCandidate]])
         Sorted list of candidates.
     """
     mjds = []
+    observation_ids = []
     for candidate_i in candidates:
         if isinstance(candidate_i, PrecoveryCandidate):
             mjds.append(candidate_i.mjd)
+            observation_ids.append(candidate_i.observation_id)
         elif isinstance(candidate_i, FrameCandidate):
             mjds.append(candidate_i.exposure_mjd_mid)
+            # Add empty observation ID since frame candidates don't have one
+            # Frames, so this is fine
+            observation_ids.append("")
         else:
             raise TypeError("Candidates must be PrecoveryCandidate or FrameCandidate")
 
     cand_array = np.array(candidates)
-    return cand_array[np.argsort(mjds)].tolist()
+    mjds = np.array(mjds)
+    observation_ids = np.array(observation_ids)
+    # Primary sort key is MJD, secondary sort key is observation ID
+    # lexsort takes sort order in reverse
+    sorted_indices = np.lexsort((observation_ids, mjds))
+    return cand_array[sorted_indices].tolist()
 
 
 class PrecoveryDatabase:

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -5,7 +5,6 @@ import os
 from typing import Iterable, Iterator, List, Optional, Union
 
 import numpy as np
-import pandas as pd
 
 from .config import Config, DefaultConfig
 from .frame_db import FrameDB, FrameIndex, Observation
@@ -85,24 +84,12 @@ def sort_candidates(
     List[Union[PrecoveryCandidate, FrameCandidate]]
         Sorted list of candidates.
     """
-    mjds = []
-    observation_ids = []
-    for candidate_i in candidates:
-        if isinstance(candidate_i, PrecoveryCandidate):
-            mjds.append(candidate_i.mjd)
-            observation_ids.append(candidate_i.observation_id)
-        elif isinstance(candidate_i, FrameCandidate):
-            mjds.append(candidate_i.exposure_mjd_mid)
-            # Add empty observation ID since frame candidates don't have one
-            # Frames, so this is fine
-            observation_ids.append("")
-        else:
-            raise TypeError("Candidates must be PrecoveryCandidate or FrameCandidate")
-
-    cand_array = np.array(candidates)
-    df = pd.DataFrame({"mjd": mjds, "observation_id": observation_ids})
-    df.sort_values(by=["mjd", "observation_id"], inplace=True)
-    return cand_array[df.index.values].tolist()
+    return sorted(
+        candidates,
+        key=lambda c: (c.mjd, c.observation_id)
+        if isinstance(c, PrecoveryCandidate)
+        else (c.exposure_mjd_mid, ""),
+    )
 
 
 class PrecoveryDatabase:

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -5,6 +5,7 @@ import os
 from typing import Iterable, Iterator, List, Optional, Union
 
 import numpy as np
+import pandas as pd
 
 from .config import Config, DefaultConfig
 from .frame_db import FrameDB, FrameIndex, Observation
@@ -67,7 +68,9 @@ class FrameCandidate:
     dataset_id: str
 
 
-def sort_candidates(candidates: List[Union[PrecoveryCandidate, FrameCandidate]]):
+def sort_candidates(
+    candidates: List[Union[PrecoveryCandidate, FrameCandidate]]
+) -> List[Union[PrecoveryCandidate, FrameCandidate]]:
     """
     Sort candidates by ascending MJD. For precovery candidates, use the MJD of the observation.
     For frame candidates, use the MJD at the midpoint of the exposure.
@@ -97,12 +100,9 @@ def sort_candidates(candidates: List[Union[PrecoveryCandidate, FrameCandidate]])
             raise TypeError("Candidates must be PrecoveryCandidate or FrameCandidate")
 
     cand_array = np.array(candidates)
-    mjds = np.array(mjds)
-    observation_ids = np.array(observation_ids)
-    # Primary sort key is MJD, secondary sort key is observation ID
-    # lexsort takes sort order in reverse
-    sorted_indices = np.lexsort((observation_ids, mjds))
-    return cand_array[sorted_indices].tolist()
+    df = pd.DataFrame({"mjd": mjds, "observation_id": observation_ids})
+    df.sort_values(by=["mjd", "observation_id"], inplace=True)
+    return cand_array[df.index.values].tolist()
 
 
 class PrecoveryDatabase:

--- a/tests/test_precovery_db.py
+++ b/tests/test_precovery_db.py
@@ -1,4 +1,9 @@
-from precovery.precovery_db import PrecoveryDatabase
+from precovery.precovery_db import (
+    FrameCandidate,
+    PrecoveryCandidate,
+    PrecoveryDatabase,
+    sort_candidates,
+)
 from precovery.sourcecatalog import bundle_into_frames
 
 from .testutils import make_sourceobs
@@ -46,3 +51,118 @@ def test_find_observations_in_regions(tmp_path):
     # Should get one result within 1 arcsec
     results = db.find_observations_in_radius(1, 2, 1 / 3600.0, "testobs")
     assert len(list(results)) == 1
+
+
+def test_sort_candidates():
+
+    cand1 = PrecoveryCandidate(
+        mjd=1,
+        ra_deg=1,
+        dec_deg=1,
+        ra_sigma_arcsec=1,
+        dec_sigma_arcsec=1,
+        mag=1,
+        mag_sigma=1,
+        filter="r",
+        obscode="I41",
+        exposure_id="exp1",
+        exposure_mjd_start=1,
+        exposure_mjd_mid=1,
+        exposure_duration=1,
+        observation_id="obs1",
+        healpix_id=1,
+        pred_ra_deg=1,
+        pred_dec_deg=1,
+        pred_vra_degpday=1,
+        pred_vdec_degpday=1,
+        delta_ra_arcsec=1,
+        delta_dec_arcsec=1,
+        distance_arcsec=1,
+        dataset_id="dataset1",
+    )
+    # Same time as cand1 but different obs
+    cand2 = PrecoveryCandidate(
+        mjd=1,
+        ra_deg=2,
+        dec_deg=2,
+        ra_sigma_arcsec=2,
+        dec_sigma_arcsec=2,
+        mag=2,
+        mag_sigma=2,
+        filter="r",
+        obscode="I41",
+        exposure_id=2,
+        exposure_mjd_start=2,
+        exposure_mjd_mid=2,
+        exposure_duration=2,
+        observation_id="obs2",
+        healpix_id=2,
+        pred_ra_deg=2,
+        pred_dec_deg=2,
+        pred_vra_degpday=2,
+        pred_vdec_degpday=2,
+        delta_ra_arcsec=2,
+        delta_dec_arcsec=2,
+        distance_arcsec=2,
+        dataset_id="dataset2",
+    )
+
+    cand3 = PrecoveryCandidate(
+        mjd=2,
+        ra_deg=2,
+        dec_deg=2,
+        ra_sigma_arcsec=2,
+        dec_sigma_arcsec=2,
+        mag=2,
+        mag_sigma=2,
+        filter="r",
+        obscode="I41",
+        exposure_id=2,
+        exposure_mjd_start=2,
+        exposure_mjd_mid=2,
+        exposure_duration=2,
+        observation_id="obs4",
+        healpix_id=2,
+        pred_ra_deg=2,
+        pred_dec_deg=2,
+        pred_vra_degpday=2,
+        pred_vdec_degpday=2,
+        delta_ra_arcsec=2,
+        delta_dec_arcsec=2,
+        distance_arcsec=2,
+        dataset_id="dataset2",
+    )
+
+    cand4 = FrameCandidate(
+        filter="r",
+        obscode="I41",
+        exposure_id=3,
+        exposure_mjd_start=3,
+        exposure_mjd_mid=3,
+        exposure_duration=3,
+        healpix_id=3,
+        pred_ra_deg=3,
+        pred_dec_deg=3,
+        pred_vra_degpday=3,
+        pred_vdec_degpday=3,
+        dataset_id="dataset3",
+    )
+
+    cand5 = FrameCandidate(
+        filter="r",
+        obscode="I41",
+        exposure_id=3,
+        exposure_mjd_start=4,
+        exposure_mjd_mid=4,
+        exposure_duration=4,
+        healpix_id=3,
+        pred_ra_deg=3,
+        pred_dec_deg=3,
+        pred_vra_degpday=3,
+        pred_vdec_degpday=3,
+        dataset_id="dataset3",
+    )
+
+    cands = [cand5, cand3, cand2, cand1, cand4]
+    cands_sorted = sort_candidates(cands)
+    assert cands_sorted == [cand1, cand2, cand3, cand4, cand5]


### PR DESCRIPTION
Sort candidates by MJD, and then by Observation ID. If sorting a FrameCandidate, it will be sort on midpoint exposure time with a dummy observation ID. As precovery currently works, one orbit will never return the same frame more than once. 