### PR TITLE
Proposal: Switch to non-dataframe tupled results

### DIFF
--- a/precovery/__init__.py
+++ b/precovery/__init__.py
@@ -1,1 +1,2 @@
 from .main import precover  # noqa: F401
+from .utils import candidates_to_dataframe, frames_to_dataframe  # noqa: F401

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -412,7 +412,6 @@ class PrecoveryDatabase:
                 orbit=orbit_window,
                 obscode=obscode,
                 tolerance=tolerance,
-                include_frame_candidates=include_frame_candidates,
                 datasets=datasets,
             )
 
@@ -423,7 +422,6 @@ class PrecoveryDatabase:
         orbit: Orbit,
         obscode: str,
         tolerance: float,
-        include_frame_candidates: bool,
         datasets: Optional[set[str]],
     ):
         # Gather all MJDs and their associated healpixels in the window.
@@ -467,7 +465,6 @@ class PrecoveryDatabase:
                     obscode=obscode,
                     mjd=timestamp,
                     tolerance=tolerance,
-                    include_frame_candidates=include_frame_candidates,
                     datasets=datasets,
                 )
 
@@ -509,7 +506,7 @@ class PrecoveryDatabase:
             # Note that for the frame candidate we report the predicted
             # ephemeris at the exposure midpoint not at the observation
             # times which may differ from the exposure midpoint time
-            if not any_matches and (include_frame_candidates):
+            if not any_matches:
                 logger.debug("no observations found in this frame")
                 frame_candidate = FrameCandidate.from_frame(f, ephem)
                 yield frame_candidate

--- a/precovery/utils.py
+++ b/precovery/utils.py
@@ -1,0 +1,21 @@
+from typing import List
+
+import pandas as pd
+
+from .precovery_db import FrameCandidate, PrecoveryCandidate
+
+
+def candidates_to_dataframe(candidates: List[PrecoveryCandidate]):
+    """Convert a list of precovery candidates to a pandas dataframe."""
+    if len(candidates) == 0:
+        return pd.DataFrame()
+    else:
+        return pd.DataFrame([c.to_dict() for c in candidates])
+
+
+def frames_to_dataframe(frames: List[FrameCandidate]):
+    """Convert a list of frame candidates to a pandas dataframe."""
+    if len(frames) == 0:
+        return pd.DataFrame()
+    else:
+        return pd.DataFrame([c.to_dict() for c in frames])

--- a/tests/test_precovery_db.py
+++ b/tests/test_precovery_db.py
@@ -2,7 +2,7 @@ from precovery.precovery_db import (
     FrameCandidate,
     PrecoveryCandidate,
     PrecoveryDatabase,
-    sort_candidates,
+    sift_candidates,
 )
 from precovery.sourcecatalog import bundle_into_frames
 
@@ -53,8 +53,7 @@ def test_find_observations_in_regions(tmp_path):
     assert len(list(results)) == 1
 
 
-def test_sort_candidates():
-
+def test_sift_candidates():
     cand1 = PrecoveryCandidate(
         mjd=1,
         ra_deg=1,
@@ -164,5 +163,5 @@ def test_sort_candidates():
     )
 
     cands = [cand5, cand3, cand2, cand1, cand4]
-    cands_sorted = sort_candidates(cands)
-    assert cands_sorted == [cand1, cand2, cand3, cand4, cand5]
+    cands_sorted = sift_candidates(cands)
+    assert cands_sorted == ([cand1, cand2, cand3], [cand4, cand5])

--- a/tests/test_precovery_search.py
+++ b/tests/test_precovery_search.py
@@ -26,10 +26,11 @@ def test_precover(precovery_db, sample_orbits):
     precovery_db.frames.add_frames(ds_id, frames)
 
     # Do the search. We should find the three observations we inserted.
-    results = list(precovery_db.precover(orbit))
-    assert len(results) == 3
+    matches, misses = list(precovery_db.precover(orbit))
+    assert len(matches) == 3
+    assert len(misses) == 0
 
-    have_ids = set(r.observation_id for r in results)
+    have_ids = set(r.observation_id for r in matches)
     want_ids = set(o.id.decode("utf8") for o in object_observations)
     assert have_ids == want_ids
 
@@ -56,18 +57,18 @@ def test_precover_dataset_filter(precovery_db, sample_orbits):
 
     # Do the search with no dataset filters. We should find all six
     # observations we inserted.
-    results = list(precovery_db.precover(orbit))
-    assert len(results) == 6
+    matches, misses = list(precovery_db.precover(orbit))
+    assert len(matches) == 6
 
-    have_ids = set(r.observation_id for r in results)
+    have_ids = set(r.observation_id for r in matches)
     want_ids = set(o.id.decode("utf8") for o in (ds1_observations + ds2_observations))
     assert have_ids == want_ids
 
     # Now repeat the search, but filter to just one dataset. We should
     # only find that dataset's observations.
-    results = list(precovery_db.precover(orbit, datasets={ds1_id}))
-    assert len(results) == 3
+    matches, misses = list(precovery_db.precover(orbit, datasets={ds1_id}))
+    assert len(matches) == 3
 
-    have_ids = set(r.observation_id for r in results)
+    have_ids = set(r.observation_id for r in matches)
     want_ids = set(o.id.decode("utf8") for o in ds1_observations)
     assert have_ids == want_ids

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,216 @@
+from precovery.precovery_db import FrameCandidate, PrecoveryCandidate
+from precovery.utils import candidates_to_dataframe, frames_to_dataframe
+
+
+def test_candidates_to_dataframe():
+    """Test conversion of a list of precovery candidates to a pandas dataframe."""
+    cand1 = PrecoveryCandidate(
+        mjd=1,
+        ra_deg=1,
+        dec_deg=1,
+        ra_sigma_arcsec=1,
+        dec_sigma_arcsec=1,
+        mag=1,
+        mag_sigma=1,
+        filter="r",
+        obscode="I41",
+        exposure_id="exp1",
+        exposure_mjd_start=1,
+        exposure_mjd_mid=1,
+        exposure_duration=1,
+        observation_id="obs1",
+        healpix_id=1,
+        pred_ra_deg=1,
+        pred_dec_deg=1,
+        pred_vra_degpday=1,
+        pred_vdec_degpday=1,
+        delta_ra_arcsec=1,
+        delta_dec_arcsec=1,
+        distance_arcsec=1,
+        dataset_id="dataset1",
+    )
+    # Same time as cand1 but different obs
+    cand2 = PrecoveryCandidate(
+        mjd=1,
+        ra_deg=2,
+        dec_deg=2,
+        ra_sigma_arcsec=2,
+        dec_sigma_arcsec=2,
+        mag=2,
+        mag_sigma=2,
+        filter="r",
+        obscode="I41",
+        exposure_id=2,
+        exposure_mjd_start=2,
+        exposure_mjd_mid=2,
+        exposure_duration=2,
+        observation_id="obs2",
+        healpix_id=2,
+        pred_ra_deg=2,
+        pred_dec_deg=2,
+        pred_vra_degpday=2,
+        pred_vdec_degpday=2,
+        delta_ra_arcsec=2,
+        delta_dec_arcsec=2,
+        distance_arcsec=2,
+        dataset_id="dataset2",
+    )
+
+    cand3 = PrecoveryCandidate(
+        mjd=3,
+        ra_deg=3,
+        dec_deg=3,
+        ra_sigma_arcsec=3,
+        dec_sigma_arcsec=3,
+        mag=3,
+        mag_sigma=3,
+        filter="r",
+        obscode="I41",
+        exposure_id=3,
+        exposure_mjd_start=3,
+        exposure_mjd_mid=3,
+        exposure_duration=3,
+        observation_id="obs3",
+        healpix_id=3,
+        pred_ra_deg=3,
+        pred_dec_deg=3,
+        pred_vra_degpday=3,
+        pred_vdec_degpday=3,
+        delta_ra_arcsec=3,
+        delta_dec_arcsec=3,
+        distance_arcsec=3,
+        dataset_id="dataset3",
+    )
+
+    as_df = candidates_to_dataframe([cand1, cand2, cand3])
+    assert len(as_df) == 3
+    assert as_df["mjd"].iloc[0] == 1
+    assert as_df["mjd"].iloc[1] == 1
+    assert as_df["mjd"].iloc[2] == 3
+    assert as_df["ra_deg"].iloc[0] == 1
+    assert as_df["ra_deg"].iloc[1] == 2
+    assert as_df["ra_deg"].iloc[2] == 3
+    assert as_df["dec_deg"].iloc[0] == 1
+    assert as_df["dec_deg"].iloc[1] == 2
+    assert as_df["dec_deg"].iloc[2] == 3
+    assert as_df["ra_sigma_arcsec"].iloc[0] == 1
+    assert as_df["ra_sigma_arcsec"].iloc[1] == 2
+    assert as_df["ra_sigma_arcsec"].iloc[2] == 3
+    assert as_df["dec_sigma_arcsec"].iloc[0] == 1
+    assert as_df["dec_sigma_arcsec"].iloc[1] == 2
+    assert as_df["dec_sigma_arcsec"].iloc[2] == 3
+    assert as_df["mag"].iloc[0] == 1
+    assert as_df["mag"].iloc[1] == 2
+    assert as_df["mag"].iloc[2] == 3
+    assert as_df["mag_sigma"].iloc[0] == 1
+    assert as_df["mag_sigma"].iloc[1] == 2
+    assert as_df["mag_sigma"].iloc[2] == 3
+    assert as_df["filter"].iloc[0] == "r"
+    assert as_df["filter"].iloc[1] == "r"
+    assert as_df["filter"].iloc[2] == "r"
+    assert as_df["obscode"].iloc[0] == "I41"
+    assert as_df["obscode"].iloc[1] == "I41"
+    assert as_df["obscode"].iloc[2] == "I41"
+    assert as_df["exposure_id"].iloc[0] == "exp1"
+    assert as_df["exposure_id"].iloc[1] == 2
+    assert as_df["exposure_id"].iloc[2] == 3
+    assert as_df["exposure_mjd_start"].iloc[0] == 1
+    assert as_df["exposure_mjd_start"].iloc[1] == 2
+    assert as_df["exposure_mjd_start"].iloc[2] == 3
+    assert as_df["exposure_mjd_mid"].iloc[0] == 1
+    assert as_df["exposure_mjd_mid"].iloc[1] == 2
+    assert as_df["exposure_mjd_mid"].iloc[2] == 3
+    assert as_df["exposure_duration"].iloc[0] == 1
+    assert as_df["exposure_duration"].iloc[1] == 2
+    assert as_df["exposure_duration"].iloc[2] == 3
+    assert as_df["observation_id"].iloc[0] == "obs1"
+    assert as_df["observation_id"].iloc[1] == "obs2"
+    assert as_df["observation_id"].iloc[2] == "obs3"
+    assert as_df["healpix_id"].iloc[0] == 1
+    assert as_df["healpix_id"].iloc[1] == 2
+    assert as_df["healpix_id"].iloc[2] == 3
+    assert as_df["pred_ra_deg"].iloc[0] == 1
+    assert as_df["pred_ra_deg"].iloc[1] == 2
+    assert as_df["pred_ra_deg"].iloc[2] == 3
+    assert as_df["pred_dec_deg"].iloc[0] == 1
+    assert as_df["pred_dec_deg"].iloc[1] == 2
+    assert as_df["pred_dec_deg"].iloc[2] == 3
+    assert as_df["pred_vra_degpday"].iloc[0] == 1
+    assert as_df["pred_vra_degpday"].iloc[1] == 2
+    assert as_df["pred_vra_degpday"].iloc[2] == 3
+    assert as_df["pred_vdec_degpday"].iloc[0] == 1
+    assert as_df["pred_vdec_degpday"].iloc[1] == 2
+    assert as_df["pred_vdec_degpday"].iloc[2] == 3
+    assert as_df["delta_ra_arcsec"].iloc[0] == 1
+    assert as_df["delta_ra_arcsec"].iloc[1] == 2
+    assert as_df["delta_ra_arcsec"].iloc[2] == 3
+    assert as_df["delta_dec_arcsec"].iloc[0] == 1
+    assert as_df["delta_dec_arcsec"].iloc[1] == 2
+    assert as_df["delta_dec_arcsec"].iloc[2] == 3
+    assert as_df["distance_arcsec"].iloc[0] == 1
+    assert as_df["distance_arcsec"].iloc[1] == 2
+    assert as_df["distance_arcsec"].iloc[2] == 3
+    assert as_df["dataset_id"].iloc[0] == "dataset1"
+    assert as_df["dataset_id"].iloc[1] == "dataset2"
+    assert as_df["dataset_id"].iloc[2] == "dataset3"
+
+
+def test_frame_candidates_to_dataframe():
+    """Test that we can convert a list of FrameCandidate objects to a pandas DataFrame."""
+    cand1 = FrameCandidate(
+        filter="r",
+        obscode="I41",
+        exposure_id=3,
+        exposure_mjd_start=3,
+        exposure_mjd_mid=3,
+        exposure_duration=3,
+        healpix_id=3,
+        pred_ra_deg=3,
+        pred_dec_deg=3,
+        pred_vra_degpday=3,
+        pred_vdec_degpday=3,
+        dataset_id="dataset3",
+    )
+
+    cand2 = FrameCandidate(
+        filter="r",
+        obscode="I41",
+        exposure_id="str_exposure_id",
+        exposure_mjd_start=4,
+        exposure_mjd_mid=4,
+        exposure_duration=4,
+        healpix_id=3,
+        pred_ra_deg=3,
+        pred_dec_deg=3,
+        pred_vra_degpday=3,
+        pred_vdec_degpday=3,
+        dataset_id="dataset3",
+    )
+
+    as_df = frames_to_dataframe([cand1, cand2])
+
+    assert as_df["filter"].iloc[0] == "r"
+    assert as_df["obscode"].iloc[0] == "I41"
+    assert as_df["exposure_id"].iloc[0] == 3
+    assert as_df["exposure_mjd_start"].iloc[0] == 3
+    assert as_df["exposure_mjd_mid"].iloc[0] == 3
+    assert as_df["exposure_duration"].iloc[0] == 3
+    assert as_df["healpix_id"].iloc[0] == 3
+    assert as_df["pred_ra_deg"].iloc[0] == 3
+    assert as_df["pred_dec_deg"].iloc[0] == 3
+    assert as_df["pred_vra_degpday"].iloc[0] == 3
+    assert as_df["pred_vdec_degpday"].iloc[0] == 3
+    assert as_df["dataset_id"].iloc[0] == "dataset3"
+
+    assert as_df["filter"].iloc[1] == "r"
+    assert as_df["obscode"].iloc[1] == "I41"
+    assert as_df["exposure_id"].iloc[1] == "str_exposure_id"
+    assert as_df["exposure_mjd_start"].iloc[1] == 4
+    assert as_df["exposure_mjd_mid"].iloc[1] == 4
+    assert as_df["exposure_duration"].iloc[1] == 4
+    assert as_df["healpix_id"].iloc[1] == 3
+    assert as_df["pred_ra_deg"].iloc[1] == 3
+    assert as_df["pred_dec_deg"].iloc[1] == 3
+    assert as_df["pred_vra_degpday"].iloc[1] == 3
+    assert as_df["pred_vdec_degpday"].iloc[1] == 3
+    assert as_df["dataset_id"].iloc[1] == "dataset3"


### PR DESCRIPTION
This PR switches the primary interface for `precovery.precover` from returning a `pd.DataFrame` of unioned precovery candidates and frame candidates into two separate return values. The new format takes the form `Tuple[List[PrecoveryCandidate, FrameCandidate]]`. The second major change eliminates the `include_frame_candidates` option, opting instead to always return frame candidates.

Old

```python
>>> df = precovery.precover(...)
>>> df.columns
Index(['mjd', 'ra_deg', 'dec_deg', 'ra_sigma_arcsec', 'dec_sigma_arcsec',
       'mag', 'mag_sigma', 'filter', 'obscode', 'exposure_id',
       'exposure_mjd_start', 'exposure_mjd_mid', 'exposure_duration',
       'observation_id', 'healpix_id', 'pred_ra_deg', 'pred_dec_deg',
       'pred_vra_degpday', 'pred_vdec_degpday', 'delta_ra_arcsec',
       'delta_dec_arcsec', 'distance_arcsec', 'dataset_id', 'orbit_id'],
      dtype='object')
```

New

```python
>>> precovery_candidates, frame_candidates = precovery.precover()
>>> print(precovery_candidates)
[PrecoveryCandidate(mjd=50000.0, ra_deg=205.88903218124665, dec_deg=-15.381163692732548, ra_sigma_arcsec=10800.0, dec_sigma_arcsec=14400.0, mag=5.0, mag_sigma=6.0, exposure_mjd_start=50000.0, exposure_mjd_mid=50000.0, filter='filter', obscode='I41', exposure_id='exposure', exposure_duration=30.0, observation_id='bjewnltujtgbffge', healpix_id=6715579247, pred_ra_deg=205.88903218124662, pred_dec_deg=-15.381163692732573, pred_vra_degpday=1.5288441441416185, pred_vdec_degpday=-0.8115017070879296, delta_ra_arcsec=1.0231815394945443e-10, delta_dec_arcsec=8.952838470577262e-11, distance_arcsec=1.9897641567037682e-10, dataset_id='test_dataset_2'), ...]
```

## "why two values instead of a single value?" 
The two objects being returned have distinct schemas and represent distinct types. When performing work on the results of a precovery search, most downstream tasks involve only the `PrecoveryCandidate` matches. Returning the results as a unioned iterable requires every downstream consumer to filter them out with type checking. Even the cases where both matches and misses are wanted, typically the sets are separated when additional work is performed.

A unioned dataframe is doubly difficult because now the filtering must be done heuristically by analyzing column values (e.g. `df.dropna(subset=["mjd"])`) and hoping that the resulting subset is valid. This unioned schema also causes problems when attempting to cast column types, but some fields are null, such as casting `observation_id` to `str` which in turn causes the frame candidate row `NaNs` to become literal `"nan"`. 

## Why not two dataframes?
Dataframes have very limited typing semantics. It is difficult to make guarantees about nullability. By returning more specific types, downstream consumers can more easily inspect and react to individual rows. I've added two utility functions to initialize dataframes from the dataclasses when wanted (`as_df = candidates_to_dataframes(precovery_candidates)`).

## Why always return frame candidates?
There is almost no perceived performance benefit in avoiding returning the frame candidates. By always returning a tuple (matches, misses), the contents of the return values are never surprising. If a downstream consumer does not care about the frame candidates, it can simply discard them. 

## Other changes
I moved the sorting logic further up into the main `PrecoveryDatabase.precover` function (`precovery.precovery_db.sift_candidates`). This ensures that the `precovery.main.precover` function is just syntactic sugar for the `db.precover` function and that the two return identical results. Previously the functional version performed separate sorting and type casting (observation_id -> str) that differed from the streaming style results of the db method.