### PR TITLE
Fix read write

### DIFF
--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -80,7 +80,7 @@ class FrameIndex:
         self.mode = mode
 
         if self.mode not in {"r", "w"}:
-            raise ValueError(f"mode must be one of {{'r', 'w'}}")
+            raise ValueError(f"mode {self.mode} must be one of {{'r', 'w'}}")
 
         if self.db_uri.startswith("sqlite:///") and (self.mode == "r"):
             if not self.db_uri.endswith("?mode=ro"):

--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -104,7 +104,7 @@ class FrameIndex:
         Reflect the metadata and assign references to table objects
         """
         self._metadata = sq.MetaData()
-        self._metadata.reflect(self.db)
+        self._metadata.reflect(bind=self.db)
         self.frames = self._metadata.tables["frames"]
         self.datasets = self._metadata.tables["datasets"]
 

--- a/precovery/frame_db.py
+++ b/precovery/frame_db.py
@@ -75,37 +75,48 @@ class Dataset:
 
 
 class FrameIndex:
-    def __init__(self, db_engine):
-        self.db = db_engine
-        self.dbconn = self.db.connect()
-        self.initialize_tables()
+    def __init__(self, db_uri: str, mode: str = "r"):
+        self.db_uri = db_uri
+        self.mode = mode
 
-    @classmethod
-    def open(cls, db_uri, mode: str = "r"):
-        if (mode != "r") and (mode != "w"):
-            err = "mode should be one of {'r', 'w'}"
-            raise ValueError(err)
+        if self.mode not in {"r", "w"}:
+            raise ValueError(f"mode must be one of {{'r', 'w'}}")
 
-        if db_uri.startswith("sqlite:///") and (mode == "r"):
-            db_uri += "?mode=ro"
+        if self.db_uri.startswith("sqlite:///") and (self.mode == "r"):
+            if not self.db_uri.endswith("?mode=ro"):
+                self.db_uri += "?mode=ro"
 
         # future=True is required here for SQLAlchemy 2.0 API usage
         # while we migrate from 1.x up. Version 2 is incompatible with
         # dagster, so we need to actually pin to 1.x, but future=True
         # lets us use the 2.0 API in this code.
-        engine = sq.create_engine(db_uri, connect_args={"timeout": 60}, future=True)
+        self.db = sq.create_engine(db_uri, connect_args={"timeout": 60}, future=True)
+        self.dbconn = self.db.connect()
 
-        # Check if fast_query index exists (older databases may not have it)
-        # if it doesn't throw a warning with the command to create it
-        con = engine.connect()
-        curs = con.execute(
+        if self.mode == "w":
+            self._create_tables()
+        if self.mode == "r":
+            self._load_tables()
+        self._check_fast_query()
+
+    def _load_tables(self):
+        """
+        Reflect the metadata and assign references to table objects
+        """
+        self._metadata = sq.MetaData()
+        self._metadata.reflect(self.db)
+        self.frames = self._metadata.tables["frames"]
+        self.datasets = self._metadata.tables["datasets"]
+
+    def _check_fast_query(self):
+        curs = self.dbconn.execute(
             sq.text(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='frames';"
             )
         )
         table_names = [row[0] for row in curs.fetchall()]
         if "frames" in table_names:
-            curs = con.execute(
+            curs = self.dbconn.execute(
                 sq.text("SELECT name FROM sqlite_master WHERE type = 'index';")
             )
             index_names = [row[0] for row in curs.fetchall()]
@@ -117,9 +128,6 @@ class FrameIndex:
                     " (exposure_mjd_mid, healpixel, obscode);\n"
                 )
                 warnings.warn(warning, UserWarning)
-        con.close()
-
-        return cls(engine)
 
     def close(self):
         self.dbconn.close()
@@ -475,7 +483,7 @@ class FrameIndex:
         dataset_ids = {dataset_id[0] for dataset_id in dataset_ids}
         return dataset_ids
 
-    def initialize_tables(self):
+    def _create_tables(self):
         self._metadata = sq.MetaData()
         self.frames = sq.Table(
             "frames",

--- a/precovery/precovery_db.py
+++ b/precovery/precovery_db.py
@@ -224,7 +224,7 @@ class PrecoveryDatabase:
                 )
 
         frame_idx_db = "sqlite:///" + os.path.join(directory, "index.db")
-        frame_idx = FrameIndex.open(frame_idx_db, mode=mode)
+        frame_idx = FrameIndex(frame_idx_db, mode=mode)
 
         data_path = os.path.join(directory, "data")
         frame_db = FrameDB(
@@ -245,7 +245,7 @@ class PrecoveryDatabase:
         os.makedirs(directory, exist_ok=True)
 
         frame_idx_db = "sqlite:///" + os.path.join(directory, "index.db")
-        frame_idx = FrameIndex.open(frame_idx_db)
+        frame_idx = FrameIndex(frame_idx_db, mode="w")
 
         config = Config(nside=nside, data_file_max_size=data_file_max_size)
         config.to_json(os.path.join(directory, "config.json"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,7 @@ def test_db():
 
 @pytest.fixture
 def frame_index(tmp_path):
-    fidx = FrameIndex.open("sqlite:///" + str(tmp_path) + "/test.db", mode="r")
-    fidx.initialize_tables()
+    fidx = FrameIndex("sqlite:///" + str(tmp_path) + "/test.db", mode="w")
     yield fidx
     fidx.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def frame_db(tmp_path, frame_index):
 
 @pytest.fixture
 def precovery_db(tmp_path, frame_db):
-    yield PrecoveryDatabase.from_dir(str(tmp_path), create=True)
+    yield PrecoveryDatabase.from_dir(str(tmp_path), mode="w", create=True)
 
 
 @pytest.fixture

--- a/tests/test_frame_db.py
+++ b/tests/test_frame_db.py
@@ -31,6 +31,14 @@ def test_fast_query_warning(test_db):
             );"""
     )
 
+    con.execute(
+        """
+        CREATE TABLE datasets (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+            );"""
+    )
+
     with pytest.warns(UserWarning):
         FrameIndex("sqlite:///" + test_db, mode="r")
 

--- a/tests/test_frame_db.py
+++ b/tests/test_frame_db.py
@@ -32,7 +32,7 @@ def test_fast_query_warning(test_db):
     )
 
     with pytest.warns(UserWarning):
-        FrameIndex.open("sqlite:///" + test_db, mode="r")
+        FrameIndex("sqlite:///" + test_db, mode="r")
 
     return
 


### PR DESCRIPTION
The default behavior for the `FrameIndex` was to always create tables, even when in read mode. This is problematic when you want to use read only volumes.

I am also simplifying the api just slightly by removing the `open` classmethod. Currently, there isn't anywhere we initialize `FrameIndex` by directly passing in an engine or a connection object. Instead we only use string initialization, so I've normalized it to just use `__init__` based off db uri and the read/write mode.